### PR TITLE
Fix duplicate DB initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ app.config.update(
     CACHE_REDIS_URL="redis://127.0.0.1:6379/1"
 )
 db.init_app(app)
-db.init_app(app)
 ma.init_app(app)
 bc.init_app(app)
 cache = Cache(app)


### PR DESCRIPTION
## Summary
- remove redundant db.init_app call in `app.py`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685e4aafe378832c86a4a7937f1b3213